### PR TITLE
Make Ralph loop Ola's default core with pass memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ ola prompt -g "Your prompt here" -r 3
 
 The `-r` flag accepts a number between 1-10, indicating the number of recursive waves to execute. Each wave is tracked with a unique color identifier.
 
+### Ralph Loop (Core Engine)
+Ralph Loop is now the default prompt engine in Ola. Every `ola prompt` run uses iterative self-refinement with short-term memory between passes.
+
+```bash
+# Run prompt with default Ralph passes
+ola prompt -g "Design an API migration plan"
+
+# Control Ralph pass count (1-10)
+ola prompt -g "Design an API migration plan" --iterations 5
+```
+
+By default, Ola runs **3 Ralph passes**. Use `--iterations` to change pass count. Each pass critiques and improves the previous pass output, which gives Ola stronger memory and more agentic refinement behavior.
+
 ### Project Management
 Ola now supports project-based workflows with file attachments, multiple goals, and shared contexts:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@
 
 use chrono::Utc;
 use clap::Parser;
-use dialoguer::{theme::ColorfulTheme, Input, Select, Confirm};
+use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
 use serde_json::json;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -15,17 +15,17 @@ use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 // Core modules
 mod config;
-mod prompt;
-mod settings;
 mod models;
 mod project;
+mod prompt;
+mod settings;
 
 // API communication layer
 mod api;
 
 // Utility modules
-mod utils;
 mod console_utils;
+mod utils;
 
 #[derive(Parser)]
 #[command(name = "ola")]
@@ -349,27 +349,74 @@ fn main() {
             utils::output::startup_animation();
             utils::output::print_success("Application started successfully!");
             if *verbose {
-                utils::output::println_colored("Running in verbose mode!", utils::output::Color::BrightYellow);
+                utils::output::println_colored(
+                    "Running in verbose mode!",
+                    utils::output::Color::BrightYellow,
+                );
             }
             // Add custom logic here
         }
-        Some(Commands::Prompt { goals, format, warnings, clipboard, quiet, pipe, no_thinking, recursion, iterations }) => {
-            run_prompt(goals.clone(), format, warnings, *clipboard, *quiet, *pipe, *no_thinking, *recursion, *iterations);
+        Some(Commands::Prompt {
+            goals,
+            format,
+            warnings,
+            clipboard,
+            quiet,
+            pipe,
+            no_thinking,
+            recursion,
+            iterations,
+        }) => {
+            run_prompt(
+                goals.clone(),
+                format,
+                warnings,
+                *clipboard,
+                *quiet,
+                *pipe,
+                *no_thinking,
+                *recursion,
+                *iterations,
+            );
         }
-        Some(Commands::NonThink { prompt, clipboard, quiet, pipe, filter_thinking }) => {
+        Some(Commands::NonThink {
+            prompt,
+            clipboard,
+            quiet,
+            pipe,
+            filter_thinking,
+        }) => {
             run_non_think(prompt.clone(), *clipboard, *quiet, *pipe, *filter_thinking);
         }
         Some(Commands::Models { provider, quiet }) => {
             // Handle the Models subcommand
             list_models(provider.clone(), *quiet);
         }
-        Some(Commands::Settings { view, default_model, default_format, logging, log_file, reset }) => {
-            manage_settings(*view, default_model.clone(), default_format.clone(), *logging, log_file.clone(), *reset);
+        Some(Commands::Settings {
+            view,
+            default_model,
+            default_format,
+            logging,
+            log_file,
+            reset,
+        }) => {
+            manage_settings(
+                *view,
+                default_model.clone(),
+                default_format.clone(),
+                *logging,
+                log_file.clone(),
+                *reset,
+            );
         }
         Some(Commands::Project { command }) => {
             handle_project_command(command.as_ref().unwrap_or(&ProjectCommands::List));
         }
-        Some(Commands::Console { demo, loading, duration }) => {
+        Some(Commands::Console {
+            demo,
+            loading,
+            duration,
+        }) => {
             handle_console_command(*demo, loading.clone(), *duration);
         }
         Some(Commands::Configure {
@@ -378,20 +425,29 @@ fn main() {
             model: cli_model,
         }) => {
             // Interactive configuration mode with colorful banner
-            utils::output::print_banner("🤖 Welcome to Ola Interactive Configuration! 🤖", utils::output::Color::DeepSkyBlue);
+            utils::output::print_banner(
+                "🤖 Welcome to Ola Interactive Configuration! 🤖",
+                utils::output::Color::DeepSkyBlue,
+            );
 
             // Check for auto-detection from environment variables first
             if let Some(detected_config) = config::detect_provider_from_env() {
                 println!("🔍 Auto-detected configuration from environment variables:");
                 println!("   Provider: {}", detected_config.provider);
-                println!("   Model: {}", detected_config.model.as_ref().unwrap_or(&"default".to_string()));
-                
+                println!(
+                    "   Model: {}",
+                    detected_config
+                        .model
+                        .as_ref()
+                        .unwrap_or(&"default".to_string())
+                );
+
                 let confirm = Confirm::with_theme(&ColorfulTheme::default())
                     .with_prompt("Use this configuration?")
                     .default(true)
                     .interact()
                     .unwrap();
-                
+
                 if confirm {
                     // Validate the auto-detected configuration
                     println!("Validating auto-detected configuration...");
@@ -399,15 +455,18 @@ fn main() {
                         eprintln!("❌ Invalid auto-detected configuration: {}", e);
                         std::process::exit(1);
                     }
-                    
+
                     // Save auto-detected configuration
                     config::add_provider(detected_config.clone());
                     if let Err(e) = config::save() {
                         eprintln!("Failed to save configuration: {}", e);
                         std::process::exit(1);
                     }
-                    
-                    println!("✅ Auto-detected configuration saved for provider: {}", detected_config.provider);
+
+                    println!(
+                        "✅ Auto-detected configuration saved for provider: {}",
+                        detected_config.provider
+                    );
                     if let Some(model) = detected_config.model {
                         println!("Using model: {}", model);
                     }
@@ -440,7 +499,7 @@ fn main() {
                     "Gemini" => std::env::var("GEMINI_API_KEY").ok(),
                     _ => None,
                 };
-                
+
                 if let Some(key) = env_key {
                     if !key.trim().is_empty() {
                         println!("🔍 Using API key from environment variable");
@@ -459,12 +518,10 @@ fn main() {
                                     .interact()
                                     .unwrap()
                             }
-                            _ => {
-                                dialoguer::Password::with_theme(&ColorfulTheme::default())
-                                    .with_prompt(format!("{} API Key", provider_name))
-                                    .interact()
-                                    .unwrap()
-                            }
+                            _ => dialoguer::Password::with_theme(&ColorfulTheme::default())
+                                .with_prompt(format!("{} API Key", provider_name))
+                                .interact()
+                                .unwrap(),
                         }
                     }
                 } else {
@@ -481,12 +538,10 @@ fn main() {
                                 .interact()
                                 .unwrap()
                         }
-                        _ => {
-                            dialoguer::Password::with_theme(&ColorfulTheme::default())
-                                .with_prompt(format!("{} API Key", provider_name))
-                                .interact()
-                                .unwrap()
-                        }
+                        _ => dialoguer::Password::with_theme(&ColorfulTheme::default())
+                            .with_prompt(format!("{} API Key", provider_name))
+                            .interact()
+                            .unwrap(),
                     }
                 }
             };
@@ -497,7 +552,16 @@ fn main() {
             } else {
                 match provider_name.as_str() {
                     "OpenAI" => {
-                        let models = vec!["gpt-5", "gpt-4o", "gpt-4", "o3", "o3-pro", "o4", "o4-mini", "o4-mini-high"];
+                        let models = vec![
+                            "gpt-5",
+                            "gpt-4o",
+                            "gpt-4",
+                            "o3",
+                            "o3-pro",
+                            "o4",
+                            "o4-mini",
+                            "o4-mini-high",
+                        ];
                         let idx = Select::with_theme(&ColorfulTheme::default())
                             .with_prompt("Model")
                             .items(&models)
@@ -542,27 +606,38 @@ fn main() {
                         match config::fetch_ollama_models() {
                             Ok(models) => {
                                 if models.is_empty() {
-                                    utils::output::println_colored("🔍 No models found in Ollama. Using manual input...", utils::output::Color::Orange);
-                                    let model: String = Input::with_theme(&ColorfulTheme::default())
-                                        .with_prompt("Model name (e.g., llama2, mistral)")
-                                        .default("llama2".into())
-                                        .interact_text()
-                                        .unwrap();
+                                    utils::output::println_colored(
+                                        "🔍 No models found in Ollama. Using manual input...",
+                                        utils::output::Color::Orange,
+                                    );
+                                    let model: String =
+                                        Input::with_theme(&ColorfulTheme::default())
+                                            .with_prompt("Model name (e.g., llama2, mistral)")
+                                            .default("llama2".into())
+                                            .interact_text()
+                                            .unwrap();
                                     Some(model)
                                 } else {
                                     // Display available models in a select menu
-                                    utils::output::println_colored(&format!("✨ Found {} models in Ollama", models.len()), utils::output::Color::BrightGreen);
-                                    let selected_idx = Select::with_theme(&ColorfulTheme::default())
-                                        .with_prompt("Select a model")
-                                        .items(&models)
-                                        .default(0)
-                                        .interact()
-                                        .unwrap();
+                                    utils::output::println_colored(
+                                        &format!("✨ Found {} models in Ollama", models.len()),
+                                        utils::output::Color::BrightGreen,
+                                    );
+                                    let selected_idx =
+                                        Select::with_theme(&ColorfulTheme::default())
+                                            .with_prompt("Select a model")
+                                            .items(&models)
+                                            .default(0)
+                                            .interact()
+                                            .unwrap();
                                     Some(models[selected_idx].clone())
                                 }
-                            },
+                            }
                             Err(e) => {
-                                eprintln!("Failed to fetch Ollama models: {}. Using manual input...", e);
+                                eprintln!(
+                                    "Failed to fetch Ollama models: {}. Using manual input...",
+                                    e
+                                );
                                 let model: String = Input::with_theme(&ColorfulTheme::default())
                                     .with_prompt("Model name (e.g., llama2, mistral)")
                                     .default("llama2".into())
@@ -585,7 +660,13 @@ fn main() {
             };
 
             // Validate the configuration
-            utils::output::print_spinner_frame(0, &format!("Validating configuration for provider: {}", provider_config.provider));
+            utils::output::print_spinner_frame(
+                0,
+                &format!(
+                    "Validating configuration for provider: {}",
+                    provider_config.provider
+                ),
+            );
             if let Err(e) = config::validate_provider_config(&provider_config) {
                 eprintln!("❌ Invalid configuration: {}", e);
                 std::process::exit(1);
@@ -594,7 +675,10 @@ fn main() {
             // Test connection if possible
             match provider_config.provider.as_str() {
                 "Ollama" => {
-                    utils::output::println_colored("🔌 Testing connection to Ollama...", utils::output::Color::BrightCyan);
+                    utils::output::println_colored(
+                        "🔌 Testing connection to Ollama...",
+                        utils::output::Color::BrightCyan,
+                    );
                     // Simple test to check if Ollama is running
                     match std::process::Command::new("curl")
                         .arg("-s")
@@ -607,13 +691,17 @@ fn main() {
                                 utils::output::print_success("Successfully connected to Ollama");
                             } else {
                                 utils::output::clear_line();
-                                utils::output::print_error("Failed to connect to Ollama. Is it running?");
+                                utils::output::print_error(
+                                    "Failed to connect to Ollama. Is it running?",
+                                );
                                 std::process::exit(1);
                             }
                         }
                         Err(_) => {
                             utils::output::clear_line();
-                            utils::output::print_error("Failed to connect to Ollama. Is it running?");
+                            utils::output::print_error(
+                                "Failed to connect to Ollama. Is it running?",
+                            );
                             std::process::exit(1);
                         }
                     }
@@ -641,7 +729,10 @@ fn main() {
                 provider_config.provider
             ));
             if let Some(model) = provider_config.model {
-                utils::output::println_colored(&format!("🧠 Using model: {}", model), utils::output::Color::BrightBlue);
+                utils::output::println_colored(
+                    &format!("🧠 Using model: {}", model),
+                    utils::output::Color::BrightBlue,
+                );
             }
         }
         Some(Commands::Session {
@@ -660,21 +751,24 @@ fn main() {
                     eprintln!("Warnings: {}", warnings);
                 }
             }
-            
+
             // Check if we should use stdin input
             let input_content = if *pipe {
                 read_from_stdin()
             } else {
                 String::new()
             };
-            
+
             // In a real app, you'd pass input_content to the reasoning model
             let output = if input_content.is_empty() {
                 format!("Processed session for goals: {}", goals)
             } else {
-                format!("Processed session for goals: {} with input: {}", goals, input_content)
+                format!(
+                    "Processed session for goals: {} with input: {}",
+                    goals, input_content
+                )
             };
-            
+
             // Send the main output to stdout for piping
             println!("{}", output);
 
@@ -700,36 +794,55 @@ fn read_from_stdin() -> String {
     utils::piping::read_from_stdin()
 }
 
-fn run_prompt(cli_goals: Option<String>, cli_format: &str, cli_warnings: &str, clipboard: bool, quiet: bool, pipe: bool, no_thinking: bool, recursion: Option<u8>, iterations: Option<u8>) {
+fn run_prompt(
+    cli_goals: Option<String>,
+    cli_format: &str,
+    cli_warnings: &str,
+    clipboard: bool,
+    quiet: bool,
+    pipe: bool,
+    no_thinking: bool,
+    recursion: Option<u8>,
+    iterations: Option<u8>,
+) {
     // Track recursion wave number (defaults to 0 for non-recursive operations)
-    let wave_number = std::env::var("OLA_RECURSION_WAVE").ok().and_then(|s| s.parse::<u8>().ok()).unwrap_or(0);
-    
+    let wave_number = std::env::var("OLA_RECURSION_WAVE")
+        .ok()
+        .and_then(|s| s.parse::<u8>().ok())
+        .unwrap_or(0);
+
     // Log the current recursion wave if recursion is enabled
     if wave_number > 0 && !quiet {
         // Define ocean-themed colors for different waves
         let wave_colors = [
-            "\x1b[34m",  // blue
-            "\x1b[36m",  // cyan
-            "\x1b[96m",  // bright cyan
-            "\x1b[94m",  // bright blue
-            "\x1b[38;5;39m",  // deep sky blue
-            "\x1b[38;5;45m",  // turquoise
-            "\x1b[38;5;23m",  // sea green
-            "\x1b[38;5;24m",  // deep turquoise
-            "\x1b[38;5;31m",  // medium blue
-            "\x1b[38;5;37m",  // teal
+            "\x1b[34m",      // blue
+            "\x1b[36m",      // cyan
+            "\x1b[96m",      // bright cyan
+            "\x1b[94m",      // bright blue
+            "\x1b[38;5;39m", // deep sky blue
+            "\x1b[38;5;45m", // turquoise
+            "\x1b[38;5;23m", // sea green
+            "\x1b[38;5;24m", // deep turquoise
+            "\x1b[38;5;31m", // medium blue
+            "\x1b[38;5;37m", // teal
         ];
-        
+
         let color = wave_colors[(wave_number as usize - 1) % wave_colors.len()];
         let reset = "\x1b[0m";
-        
-        eprintln!("{}[RECURSION WAVE {}]{}  Processing...", color, wave_number, reset);
+
+        eprintln!(
+            "{}[RECURSION WAVE {}]{}  Processing...",
+            color, wave_number, reset
+        );
     } else if !quiet {
         utils::output::startup_animation();
         std::thread::sleep(std::time::Duration::from_millis(500));
-        utils::output::print_banner("🌊 Prompt Mode Activated 🌊", utils::output::Color::DeepSkyBlue);
+        utils::output::print_banner(
+            "🌊 Prompt Mode Activated 🌊",
+            utils::output::Color::DeepSkyBlue,
+        );
     }
-    
+
     // Read from stdin if pipe mode is enabled
     let piped_content = if pipe {
         read_from_stdin()
@@ -739,7 +852,7 @@ fn run_prompt(cli_goals: Option<String>, cli_format: &str, cli_warnings: &str, c
 
     // Check if goals were provided via CLI to determine flow
     let cli_goals_provided = cli_goals.is_some();
-    
+
     // Get goals from CLI args or prompt user
     let goals = if let Some(ref g) = cli_goals {
         g.clone()
@@ -779,7 +892,7 @@ fn run_prompt(cli_goals: Option<String>, cli_format: &str, cli_warnings: &str, c
                 .interact_text()
                 .unwrap()
         };
-        
+
         // Prompt for warnings with animation
         let warnings = {
             if !quiet {
@@ -793,7 +906,7 @@ fn run_prompt(cli_goals: Option<String>, cli_format: &str, cli_warnings: &str, c
                 .interact_text()
                 .unwrap()
         };
-        
+
         (format, warnings)
     };
 
@@ -804,31 +917,43 @@ fn run_prompt(cli_goals: Option<String>, cli_format: &str, cli_warnings: &str, c
         (goals, None)
     };
 
-    // Call the appropriate function based on whether iterations are enabled
-    let output = if let Some(max_iterations) = iterations {
-        // Use iteration mode
-        prompt::interactive_iterations(&final_goals, &format, &warnings, clipboard, context.as_deref(), no_thinking, max_iterations)
-    } else {
-        // Use standard reasoning
-        match &context {
-            Some(ctx) => prompt::structure_reasoning(&final_goals, &format, &warnings, clipboard, Some(ctx), no_thinking),
-            None => prompt::structure_reasoning(&final_goals, &format, &warnings, clipboard, None, no_thinking),
-        }
-    };
+    // Ralph loop is the default prompt engine. Iterations controls number of Ralph passes.
+    let ralph_passes = iterations.unwrap_or(3);
+    let output = prompt::ralph_loop(
+        &final_goals,
+        &format,
+        &warnings,
+        clipboard,
+        context.as_deref(),
+        no_thinking,
+        ralph_passes,
+    );
 
     if !quiet {
         utils::output::println_colored("📋 Prompt Summary:", utils::output::Color::BrightCyan);
-        utils::output::println_colored(&format!("🏆 Goals: {}", final_goals), utils::output::Color::BrightYellow);
-        utils::output::println_colored(&format!("📝 Return Format: {}", format), utils::output::Color::BrightGreen);
+        utils::output::println_colored(
+            &format!("🏆 Goals: {}", final_goals),
+            utils::output::Color::BrightYellow,
+        );
+        utils::output::println_colored(
+            &format!("📝 Return Format: {}", format),
+            utils::output::Color::BrightGreen,
+        );
         if !warnings.is_empty() {
-            utils::output::println_colored(&format!("⚠️  Warnings: {}", warnings), utils::output::Color::Orange);
+            utils::output::println_colored(
+                &format!("⚠️  Warnings: {}", warnings),
+                utils::output::Color::Orange,
+            );
         }
         if let Some(ctx) = context {
-            utils::output::println_colored(&format!("📄 Context from stdin: {} characters", ctx.len()), utils::output::Color::Purple);
+            utils::output::println_colored(
+                &format!("📄 Context from stdin: {} characters", ctx.len()),
+                utils::output::Color::Purple,
+            );
         }
         println!(); // Add space before processing
     }
-    
+
     match output {
         Ok(()) => {
             if !quiet {
@@ -836,32 +961,39 @@ fn run_prompt(cli_goals: Option<String>, cli_format: &str, cli_warnings: &str, c
                 utils::output::print_success("Prompt executed successfully! ✨");
                 println!();
             }
-            
+
             // Handle recursion if enabled and we haven't reached the limit
             if let Some(max_waves) = recursion {
                 if wave_number < max_waves {
                     // Prepare to launch the next recursion wave
                     let next_wave = wave_number + 1;
-                    
+
                     if !quiet {
-                        utils::output::print_wave_animation(next_wave as usize, &format!("Launching recursion wave {}...", next_wave));
+                        utils::output::print_wave_animation(
+                            next_wave as usize,
+                            &format!("Launching recursion wave {}...", next_wave),
+                        );
                         std::thread::sleep(std::time::Duration::from_millis(800));
                         utils::output::clear_line();
-                        utils::output::println_colored(&format!("🌊 Launching recursion wave {}...", next_wave), utils::output::Color::DeepSkyBlue);
+                        utils::output::println_colored(
+                            &format!("🌊 Launching recursion wave {}...", next_wave),
+                            utils::output::Color::DeepSkyBlue,
+                        );
                     }
-                    
+
                     // Build the command to execute the next wave
-                    let current_exe = std::env::current_exe().expect("Failed to get current executable path");
-                    
+                    let current_exe =
+                        std::env::current_exe().expect("Failed to get current executable path");
+
                     // Create a new Command instance using the current executable
                     let mut cmd = std::process::Command::new(current_exe);
-                    
+
                     // Set the OLA_RECURSION_WAVE environment variable for the child process
                     cmd.env("OLA_RECURSION_WAVE", next_wave.to_string());
-                    
+
                     // Add the "prompt" subcommand
                     cmd.arg("prompt");
-                    
+
                     // Add all the original arguments
                     if let Some(g) = &cli_goals {
                         cmd.args(["--goals", g]);
@@ -886,31 +1018,46 @@ fn run_prompt(cli_goals: Option<String>, cli_format: &str, cli_warnings: &str, c
                     if let Some(iter) = iterations {
                         cmd.args(["--iterations", &iter.to_string()]);
                     }
-                    
+
                     // Execute the command
                     match cmd.status() {
                         Ok(status) => {
                             if !status.success() {
-                                eprintln!("Recursion wave {} failed with status: {}", next_wave, status);
+                                eprintln!(
+                                    "Recursion wave {} failed with status: {}",
+                                    next_wave, status
+                                );
                             }
-                        },
+                        }
                         Err(e) => {
                             eprintln!("Failed to launch recursion wave {}: {}", next_wave, e);
                         }
                     }
                 } else if !quiet {
-                    utils::output::print_rainbow(&format!("🏁 Reached maximum recursion depth ({} waves) 🏁", max_waves));
+                    utils::output::print_rainbow(&format!(
+                        "🏁 Reached maximum recursion depth ({} waves) 🏁",
+                        max_waves
+                    ));
                 }
             }
-        },
+        }
         Err(e) => utils::output::print_error(&format!("Prompt execution failed: {:?}", e)),
     }
 }
 
-fn run_non_think(cli_prompt: Option<String>, clipboard: bool, quiet: bool, pipe: bool, filter_thinking: bool) {
+fn run_non_think(
+    cli_prompt: Option<String>,
+    clipboard: bool,
+    quiet: bool,
+    pipe: bool,
+    filter_thinking: bool,
+) {
     if !quiet {
         utils::output::print_banner("🧠 Direct Mode Activated 🧠", utils::output::Color::Purple);
-        utils::output::println_colored("Running direct prompt without thinking steps...", utils::output::Color::BrightMagenta);
+        utils::output::println_colored(
+            "Running direct prompt without thinking steps...",
+            utils::output::Color::BrightMagenta,
+        );
     }
 
     // Read from stdin if pipe mode is enabled
@@ -922,7 +1069,7 @@ fn run_non_think(cli_prompt: Option<String>, clipboard: bool, quiet: bool, pipe:
 
     // Check if prompt was provided via CLI to determine flow
     let cli_prompt_provided = cli_prompt.is_some();
-    
+
     // Get prompt from CLI args or prompt user
     let prompt = if let Some(p) = cli_prompt {
         p
@@ -959,11 +1106,14 @@ fn run_non_think(cli_prompt: Option<String>, clipboard: bool, quiet: bool, pipe:
 
     if !quiet {
         if let Some(ctx) = context {
-            utils::output::println_colored(&format!("📄 Context from stdin: {} characters", ctx.len()), utils::output::Color::Purple);
+            utils::output::println_colored(
+                &format!("📄 Context from stdin: {} characters", ctx.len()),
+                utils::output::Color::Purple,
+            );
         }
         println!(); // Add space before processing
     }
-    
+
     match output {
         Ok(()) => {
             if !quiet {
@@ -971,11 +1121,10 @@ fn run_non_think(cli_prompt: Option<String>, clipboard: bool, quiet: bool, pipe:
                 utils::output::print_success("Direct prompt executed successfully! ⚡");
                 println!();
             }
-        },
+        }
         Err(e) => utils::output::print_error(&format!("Prompt execution failed: {:?}", e)),
     }
 }
-
 
 fn append_to_log(filename: &str, entry: &str) -> std::io::Result<()> {
     let mut file = OpenOptions::new()
@@ -988,20 +1137,24 @@ fn append_to_log(filename: &str, entry: &str) -> std::io::Result<()> {
 
 /// Manage application settings
 fn manage_settings(
-    view: bool, 
-    default_model: Option<String>, 
+    view: bool,
+    default_model: Option<String>,
     default_format: Option<String>,
     logging: Option<bool>,
     log_file: Option<String>,
-    reset: bool
+    reset: bool,
 ) {
     // Try to load existing settings
     let mut settings = match settings::Settings::load() {
         Ok(s) => s,
         Err(e) => {
             eprintln!("Failed to load settings: {}", e);
-            if reset || default_model.is_some() || default_format.is_some() || 
-               logging.is_some() || log_file.is_some() {
+            if reset
+                || default_model.is_some()
+                || default_format.is_some()
+                || logging.is_some()
+                || log_file.is_some()
+            {
                 // Create default settings if we need to modify them
                 settings::Settings::default()
             } else {
@@ -1010,37 +1163,51 @@ fn manage_settings(
             }
         }
     };
-    
+
     // Reset settings if requested
     if reset {
         settings = settings::Settings::default();
         println!("Settings reset to default values");
     }
-    
+
     // Update settings with provided values
     if let Some(ref model) = default_model {
         settings.default_model = model.clone();
         println!("Default model set to: {}", settings.default_model);
     }
-    
+
     if let Some(ref format) = default_format {
         settings.defaults.return_format = format.clone();
-        println!("Default return format set to: {}", settings.defaults.return_format);
+        println!(
+            "Default return format set to: {}",
+            settings.defaults.return_format
+        );
     }
-    
+
     if let Some(enable_logging) = logging {
         settings.behavior.enable_logging = enable_logging;
-        println!("Logging is now {}", if enable_logging { "enabled" } else { "disabled" });
+        println!(
+            "Logging is now {}",
+            if enable_logging {
+                "enabled"
+            } else {
+                "disabled"
+            }
+        );
     }
-    
+
     if let Some(ref file) = log_file {
         settings.behavior.log_file = file.clone();
         println!("Log file set to: {}", settings.behavior.log_file);
     }
-    
+
     // Save settings if any changes were made
-    if reset || default_model.is_some() || default_format.is_some() || 
-       logging.is_some() || log_file.is_some() {
+    if reset
+        || default_model.is_some()
+        || default_format.is_some()
+        || logging.is_some()
+        || log_file.is_some()
+    {
         if let Err(e) = settings.save() {
             eprintln!("Failed to save settings: {}", e);
             std::process::exit(1);
@@ -1048,15 +1215,20 @@ fn manage_settings(
             println!("Settings saved successfully to: ~/.ola/settings.yaml");
         }
     }
-    
+
     // View settings if requested or if no other options were provided
-    if view || (!reset && default_model.is_none() && default_format.is_none() && 
-        logging.is_none() && log_file.is_none()) {
+    if view
+        || (!reset
+            && default_model.is_none()
+            && default_format.is_none()
+            && logging.is_none()
+            && log_file.is_none())
+    {
         // Convert settings to YAML for display
         match serde_yaml::to_string(&settings) {
             Ok(yaml) => {
                 println!("Current settings:\n{}", yaml);
-            },
+            }
             Err(e) => {
                 eprintln!("Failed to serialize settings: {}", e);
                 std::process::exit(1);
@@ -1088,7 +1260,10 @@ fn list_models(provider: Option<String>, quiet: bool) {
     };
 
     if !quiet {
-        utils::output::print_spinner_frame(0, &format!("Fetching available models for provider: {}", provider_name));
+        utils::output::print_spinner_frame(
+            0,
+            &format!("Fetching available models for provider: {}", provider_name),
+        );
         std::thread::sleep(std::time::Duration::from_millis(500));
         utils::output::clear_line();
     }
@@ -1100,13 +1275,22 @@ fn list_models(provider: Option<String>, quiet: bool) {
                 Ok(models) => {
                     if models.is_empty() {
                         if !quiet {
-                            utils::output::println_colored("🔍 No models found in Ollama.", utils::output::Color::Orange);
+                            utils::output::println_colored(
+                                "🔍 No models found in Ollama.",
+                                utils::output::Color::Orange,
+                            );
                         }
                     } else {
                         if !quiet {
-                            utils::output::print_banner("🤖 Available Ollama Models 🤖", utils::output::Color::BrightGreen);
+                            utils::output::print_banner(
+                                "🤖 Available Ollama Models 🤖",
+                                utils::output::Color::BrightGreen,
+                            );
                             for (i, model) in models.iter().enumerate() {
-                                utils::output::println_colored(&format!("  {}. {}", i + 1, model), utils::output::Color::BrightCyan);
+                                utils::output::println_colored(
+                                    &format!("  {}. {}", i + 1, model),
+                                    utils::output::Color::BrightCyan,
+                                );
                             }
                         } else {
                             // In quiet mode, just print model names (one per line)
@@ -1115,17 +1299,20 @@ fn list_models(provider: Option<String>, quiet: bool) {
                             }
                         }
                     }
-                },
+                }
                 Err(e) => {
                     eprintln!("Failed to fetch Ollama models: {}", e);
                     eprintln!("Is Ollama running on http://localhost:11434?");
                     std::process::exit(1);
                 }
             }
-        },
+        }
         "OpenAI" => {
             if !quiet {
-                utils::output::print_banner("🧠 OpenAI Models 🧠", utils::output::Color::BrightGreen);
+                utils::output::print_banner(
+                    "🧠 OpenAI Models 🧠",
+                    utils::output::Color::BrightGreen,
+                );
                 utils::output::println_colored("  1. gpt-5", utils::output::Color::BrightCyan);
                 utils::output::println_colored("  2. gpt-4o", utils::output::Color::BrightCyan);
                 utils::output::println_colored("  3. gpt-4", utils::output::Color::BrightCyan);
@@ -1133,7 +1320,10 @@ fn list_models(provider: Option<String>, quiet: bool) {
                 utils::output::println_colored("  5. o3-pro", utils::output::Color::BrightCyan);
                 utils::output::println_colored("  6. o4", utils::output::Color::BrightCyan);
                 utils::output::println_colored("  7. o4-mini", utils::output::Color::BrightCyan);
-                utils::output::println_colored("  8. o4-mini-high", utils::output::Color::BrightCyan);
+                utils::output::println_colored(
+                    "  8. o4-mini-high",
+                    utils::output::Color::BrightCyan,
+                );
             } else {
                 println!("gpt-5");
                 println!("gpt-4o");
@@ -1144,27 +1334,54 @@ fn list_models(provider: Option<String>, quiet: bool) {
                 println!("o4-mini");
                 println!("o4-mini-high");
             }
-        },
+        }
         "Gemini" => {
             if !quiet {
-                utils::output::print_banner("💎 Google Gemini Models 💎", utils::output::Color::Purple);
-                utils::output::println_colored("  1. gemini-1.5-pro", utils::output::Color::BrightCyan);
-                utils::output::println_colored("  2. gemini-1.5-flash", utils::output::Color::BrightCyan);
-                utils::output::println_colored("  3. gemini-1.0-pro", utils::output::Color::BrightCyan);
-                utils::output::println_colored("  4. gemini-1.0-pro-vision", utils::output::Color::BrightCyan);
+                utils::output::print_banner(
+                    "💎 Google Gemini Models 💎",
+                    utils::output::Color::Purple,
+                );
+                utils::output::println_colored(
+                    "  1. gemini-1.5-pro",
+                    utils::output::Color::BrightCyan,
+                );
+                utils::output::println_colored(
+                    "  2. gemini-1.5-flash",
+                    utils::output::Color::BrightCyan,
+                );
+                utils::output::println_colored(
+                    "  3. gemini-1.0-pro",
+                    utils::output::Color::BrightCyan,
+                );
+                utils::output::println_colored(
+                    "  4. gemini-1.0-pro-vision",
+                    utils::output::Color::BrightCyan,
+                );
             } else {
                 println!("gemini-1.5-pro");
                 println!("gemini-1.5-flash");
                 println!("gemini-1.0-pro");
                 println!("gemini-1.0-pro-vision");
             }
-        },
+        }
         "Anthropic" => {
             if !quiet {
-                utils::output::print_banner("🎭 Anthropic Claude Models 🎭", utils::output::Color::Orange);
-                utils::output::println_colored("  1. claude-3-opus-20240229", utils::output::Color::BrightCyan);
-                utils::output::println_colored("  2. claude-3-sonnet-20240229", utils::output::Color::BrightCyan);
-                utils::output::println_colored("  3. claude-3-haiku-20240307", utils::output::Color::BrightCyan);
+                utils::output::print_banner(
+                    "🎭 Anthropic Claude Models 🎭",
+                    utils::output::Color::Orange,
+                );
+                utils::output::println_colored(
+                    "  1. claude-3-opus-20240229",
+                    utils::output::Color::BrightCyan,
+                );
+                utils::output::println_colored(
+                    "  2. claude-3-sonnet-20240229",
+                    utils::output::Color::BrightCyan,
+                );
+                utils::output::println_colored(
+                    "  3. claude-3-haiku-20240307",
+                    utils::output::Color::BrightCyan,
+                );
                 utils::output::println_colored("  4. claude-2.1", utils::output::Color::BrightCyan);
                 utils::output::println_colored("  5. claude-2.0", utils::output::Color::BrightCyan);
             } else {
@@ -1174,7 +1391,7 @@ fn list_models(provider: Option<String>, quiet: bool) {
                 println!("claude-2.1");
                 println!("claude-2.0");
             }
-        },
+        }
         _ => {
             eprintln!("Unsupported provider: {}", provider_name);
             std::process::exit(1);
@@ -1184,9 +1401,9 @@ fn list_models(provider: Option<String>, quiet: bool) {
 
 /// Handle project management commands
 fn handle_project_command(command: &ProjectCommands) {
+    use models::{Context, Goal};
     use project::ProjectManager;
-    use models::{Goal, Context};
-    
+
     let project_manager = match ProjectManager::new() {
         Ok(pm) => pm,
         Err(e) => {
@@ -1196,7 +1413,9 @@ fn handle_project_command(command: &ProjectCommands) {
     };
 
     // Helper function to resolve project name/ID with guided selection
-    let resolve_project_with_guidance = |project_name: Option<&String>, action_description: &str| -> anyhow::Result<String> {
+    let resolve_project_with_guidance = |project_name: Option<&String>,
+                                         action_description: &str|
+     -> anyhow::Result<String> {
         match project_name {
             Some(name) => {
                 // Find project by name
@@ -1213,21 +1432,31 @@ fn handle_project_command(command: &ProjectCommands) {
                 if projects.is_empty() {
                     return Err(anyhow::anyhow!("No projects available. Create one first with 'ola project create --name <name>'"));
                 }
-                
-                let project_names: Vec<String> = projects.iter().map(|p| {
-                    let active_marker = if let Ok(Some(active_id)) = project_manager.get_active_project() {
-                        if active_id == p.id { " (active)" } else { "" }
-                    } else { "" };
-                    format!("{}{}", p.name, active_marker)
-                }).collect();
-                
+
+                let project_names: Vec<String> = projects
+                    .iter()
+                    .map(|p| {
+                        let active_marker =
+                            if let Ok(Some(active_id)) = project_manager.get_active_project() {
+                                if active_id == p.id {
+                                    " (active)"
+                                } else {
+                                    ""
+                                }
+                            } else {
+                                ""
+                            };
+                        format!("{}{}", p.name, active_marker)
+                    })
+                    .collect();
+
                 let selected_idx = Select::with_theme(&ColorfulTheme::default())
                     .with_prompt(&format!("Select project to {}", action_description))
                     .items(&project_names)
                     .default(0)
                     .interact()
                     .map_err(|e| anyhow::anyhow!("Selection failed: {}", e))?;
-                
+
                 Ok(projects[selected_idx].id.clone())
             }
         }
@@ -1236,41 +1465,55 @@ fn handle_project_command(command: &ProjectCommands) {
     match command {
         ProjectCommands::List => {
             let active_project_id = project_manager.get_active_project().unwrap_or(None);
-            
+
             match project_manager.list_projects() {
                 Ok(projects) => {
                     if projects.is_empty() {
-                        println!("No projects found. Create one with 'ola project create --name <name>'");
+                        println!(
+                            "No projects found. Create one with 'ola project create --name <name>'"
+                        );
                     } else {
                         println!("Projects:");
-                        
+
                         let mut stdout = StandardStream::stdout(ColorChoice::Auto);
-                        
+
                         for project in projects {
                             let is_active = active_project_id.as_ref() == Some(&project.id);
-                            
+
                             if is_active {
-                                let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true));
+                                let _ = stdout.set_color(
+                                    ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true),
+                                );
                                 print!("* ");
                             } else {
-                                let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)));
+                                let _ =
+                                    stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)));
                                 print!("  ");
                             }
-                            
-                            println!("{} - {} ({} files, {} goals, {} contexts)", 
-                                   project.id, 
-                                   project.name, 
-                                   project.files.len(),
-                                   project.goals.len(),
-                                   project.contexts.len());
-                            
-                            let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)).set_dimmed(true));
-                            println!("    Updated: {}", project.updated_at.format("%Y-%m-%d %H:%M:%S"));
+
+                            println!(
+                                "{} - {} ({} files, {} goals, {} contexts)",
+                                project.id,
+                                project.name,
+                                project.files.len(),
+                                project.goals.len(),
+                                project.contexts.len()
+                            );
+
+                            let _ = stdout.set_color(
+                                ColorSpec::new().set_fg(Some(Color::White)).set_dimmed(true),
+                            );
+                            println!(
+                                "    Updated: {}",
+                                project.updated_at.format("%Y-%m-%d %H:%M:%S")
+                            );
                             let _ = stdout.reset();
                         }
-                        
+
                         if let Some(active_id) = active_project_id {
-                            let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_dimmed(true));
+                            let _ = stdout.set_color(
+                                ColorSpec::new().set_fg(Some(Color::Green)).set_dimmed(true),
+                            );
                             println!("\nActive project: {}", active_id);
                             let _ = stdout.reset();
                         }
@@ -1282,25 +1525,23 @@ fn handle_project_command(command: &ProjectCommands) {
                 }
             }
         }
-        
+
         ProjectCommands::Create { name } => {
             println!("🚀 Welcome to Ola Project Creation!");
-            
+
             // Get project name - from CLI arg or prompt
             let project_name = match name {
                 Some(n) => n.clone(),
-                None => {
-                    Input::with_theme(&ColorfulTheme::default())
-                        .with_prompt("Project name")
-                        .interact_text()
-                        .map_err(|e| {
-                            eprintln!("Input failed: {}", e);
-                            std::process::exit(1);
-                        })
-                        .unwrap()
-                }
+                None => Input::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Project name")
+                    .interact_text()
+                    .map_err(|e| {
+                        eprintln!("Input failed: {}", e);
+                        std::process::exit(1);
+                    })
+                    .unwrap(),
             };
-            
+
             // Check if project with this name already exists
             let existing_projects = match project_manager.list_projects() {
                 Ok(p) => p,
@@ -1309,19 +1550,32 @@ fn handle_project_command(command: &ProjectCommands) {
                     std::process::exit(1);
                 }
             };
-            
-            if existing_projects.iter().any(|p| p.name.eq_ignore_ascii_case(&project_name)) {
-                eprintln!("A project named '{}' already exists. Please choose a different name.", project_name);
+
+            if existing_projects
+                .iter()
+                .any(|p| p.name.eq_ignore_ascii_case(&project_name))
+            {
+                eprintln!(
+                    "A project named '{}' already exists. Please choose a different name.",
+                    project_name
+                );
                 std::process::exit(1);
             }
-            
+
             match project_manager.create_project(project_name.clone()) {
                 Ok(project) => {
-                    println!("✅ Created project '{}' with ID: {}", project.name, project.id);
+                    println!(
+                        "✅ Created project '{}' with ID: {}",
+                        project.name, project.id
+                    );
                     println!("   Project directory: ~/.ola/data/projects/{}", project.id);
-                    
+
                     // Set as active project if no active project is set or if user confirms
-                    let should_set_active = if project_manager.get_active_project().unwrap_or(None).is_none() {
+                    let should_set_active = if project_manager
+                        .get_active_project()
+                        .unwrap_or(None)
+                        .is_none()
+                    {
                         true
                     } else {
                         Confirm::with_theme(&ColorfulTheme::default())
@@ -1330,7 +1584,7 @@ fn handle_project_command(command: &ProjectCommands) {
                             .interact()
                             .unwrap_or(false)
                     };
-                    
+
                     if should_set_active {
                         if let Err(e) = project_manager.set_active_project(&project.id) {
                             eprintln!("Warning: Failed to set as active project: {}", e);
@@ -1354,7 +1608,7 @@ fn handle_project_command(command: &ProjectCommands) {
                     std::process::exit(1);
                 }
             };
-            
+
             // Get project details for confirmation
             let project_name = match project_manager.load_project(&project_id) {
                 Ok(Some(proj)) => proj.name,
@@ -1367,29 +1621,36 @@ fn handle_project_command(command: &ProjectCommands) {
                     std::process::exit(1);
                 }
             };
-            
+
             if !force {
                 let confirmation = Confirm::with_theme(&ColorfulTheme::default())
-                    .with_prompt(&format!("Are you sure you want to delete project '{}'? This cannot be undone.", project_name))
+                    .with_prompt(&format!(
+                        "Are you sure you want to delete project '{}'? This cannot be undone.",
+                        project_name
+                    ))
                     .default(false)
                     .interact()
                     .unwrap();
-                
+
                 if !confirmation {
                     println!("Deletion cancelled");
                     return;
                 }
             }
-            
+
             match project_manager.delete_project(&project_id) {
                 Ok(_) => {
                     println!("✅ Deleted project '{}'", project_name);
-                    
+
                     // Clear active project if it was the deleted one
                     if let Ok(Some(active)) = project_manager.get_active_project() {
                         if active == project_id {
                             let active_file = std::env::var("HOME")
-                                .map(|h| std::path::PathBuf::from(h).join(".ola").join("active_project"))
+                                .map(|h| {
+                                    std::path::PathBuf::from(h)
+                                        .join(".ola")
+                                        .join("active_project")
+                                })
                                 .unwrap_or_default();
                             let _ = std::fs::remove_file(&active_file);
                             println!("   Cleared as active project");
@@ -1402,7 +1663,7 @@ fn handle_project_command(command: &ProjectCommands) {
                 }
             }
         }
-        
+
         ProjectCommands::Edit { project, name } => {
             let project_id = match resolve_project_with_guidance(project.as_ref(), "edit") {
                 Ok(id) => id,
@@ -1411,7 +1672,7 @@ fn handle_project_command(command: &ProjectCommands) {
                     std::process::exit(1);
                 }
             };
-            
+
             // Get current project details
             let current_project = match project_manager.load_project(&project_id) {
                 Ok(Some(proj)) => proj,
@@ -1424,29 +1685,30 @@ fn handle_project_command(command: &ProjectCommands) {
                     std::process::exit(1);
                 }
             };
-            
+
             let old_name = current_project.name.clone();
-            
+
             // Get new name - from CLI arg or prompt
             let new_name = match name {
                 Some(n) => n.clone(),
-                None => {
-                    Input::with_theme(&ColorfulTheme::default())
-                        .with_prompt("New project name")
-                        .default(old_name.clone())
-                        .interact_text()
-                        .map_err(|e| {
-                            eprintln!("Input failed: {}", e);
-                            std::process::exit(1);
-                        })
-                        .unwrap()
-                }
+                None => Input::with_theme(&ColorfulTheme::default())
+                    .with_prompt("New project name")
+                    .default(old_name.clone())
+                    .interact_text()
+                    .map_err(|e| {
+                        eprintln!("Input failed: {}", e);
+                        std::process::exit(1);
+                    })
+                    .unwrap(),
             };
-            
+
             if new_name != old_name {
                 match project_manager.edit_project(&project_id, Some(new_name.clone())) {
                     Ok(_) => {
-                        println!("✅ Updated project name from '{}' to '{}'", old_name, new_name);
+                        println!(
+                            "✅ Updated project name from '{}' to '{}'",
+                            old_name, new_name
+                        );
                     }
                     Err(e) => {
                         eprintln!("Failed to edit project: {}", e);
@@ -1457,16 +1719,17 @@ fn handle_project_command(command: &ProjectCommands) {
                 println!("No changes made to project '{}'", old_name);
             }
         }
-        
+
         ProjectCommands::Set { project } => {
-            let project_id = match resolve_project_with_guidance(project.as_ref(), "set as active") {
+            let project_id = match resolve_project_with_guidance(project.as_ref(), "set as active")
+            {
                 Ok(id) => id,
                 Err(e) => {
                     eprintln!("{}", e);
                     std::process::exit(1);
                 }
             };
-            
+
             let project_name = match project_manager.load_project(&project_id) {
                 Ok(Some(proj)) => proj.name,
                 Ok(None) => {
@@ -1478,7 +1741,7 @@ fn handle_project_command(command: &ProjectCommands) {
                     std::process::exit(1);
                 }
             };
-            
+
             match project_manager.set_active_project(&project_id) {
                 Ok(_) => {
                     println!("✅ Set '{}' as active project", project_name);
@@ -1489,7 +1752,7 @@ fn handle_project_command(command: &ProjectCommands) {
                 }
             }
         }
-        
+
         ProjectCommands::Upload { project, file } => {
             let project_id = match project {
                 Some(name) => {
@@ -1518,7 +1781,7 @@ fn handle_project_command(command: &ProjectCommands) {
                     }
                 }
             };
-            
+
             match std::fs::read(file) {
                 Ok(content) => {
                     let filename = std::path::Path::new(file)
@@ -1526,7 +1789,7 @@ fn handle_project_command(command: &ProjectCommands) {
                         .and_then(|n| n.to_str())
                         .unwrap_or("unknown")
                         .to_string();
-                    
+
                     match project_manager.upload_file(&project_id, filename, &content) {
                         Ok(file_obj) => {
                             // Update project with new file
@@ -1535,9 +1798,15 @@ fn handle_project_command(command: &ProjectCommands) {
                                 if let Err(e) = project_manager.save_project(&proj) {
                                     eprintln!("Warning: Failed to save project: {}", e);
                                 }
-                                println!("✅ Uploaded file '{}' to project '{}'", file_obj.filename, proj.name);
+                                println!(
+                                    "✅ Uploaded file '{}' to project '{}'",
+                                    file_obj.filename, proj.name
+                                );
                             } else {
-                                println!("✅ Uploaded file '{}' to project '{}'", file_obj.filename, project_id);
+                                println!(
+                                    "✅ Uploaded file '{}' to project '{}'",
+                                    file_obj.filename, project_id
+                                );
                             }
                             println!("   File ID: {}", file_obj.id);
                         }
@@ -1582,7 +1851,7 @@ fn handle_project_command(command: &ProjectCommands) {
                     }
                 }
             };
-            
+
             match project_manager.load_project(&project_id) {
                 Ok(Some(proj)) => {
                     if proj.files.is_empty() {
@@ -1590,11 +1859,13 @@ fn handle_project_command(command: &ProjectCommands) {
                     } else {
                         println!("Files in project '{}':", proj.name);
                         for file in &proj.files {
-                            println!("  {} - {} ({} bytes, {})", 
-                                   file.id, 
-                                   file.filename,
-                                   file.size,
-                                   file.uploaded_at.format("%Y-%m-%d %H:%M:%S"));
+                            println!(
+                                "  {} - {} ({} bytes, {})",
+                                file.id,
+                                file.filename,
+                                file.size,
+                                file.uploaded_at.format("%Y-%m-%d %H:%M:%S")
+                            );
                         }
                     }
                 }
@@ -1637,7 +1908,7 @@ fn handle_project_command(command: &ProjectCommands) {
                     }
                 }
             };
-            
+
             // Load or create project
             let mut proj = match project_manager.load_project(&project_id) {
                 Ok(Some(p)) => p,
@@ -1704,13 +1975,16 @@ fn handle_project_command(command: &ProjectCommands) {
                     }
                 }
             };
-            
+
             match project_manager.load_project(&project_id) {
                 Ok(Some(mut proj)) => {
                     if proj.remove_goal(goal_id) {
                         match project_manager.save_project(&proj) {
                             Ok(_) => {
-                                println!("✅ Removed goal '{}' from project '{}'", goal_id, proj.name);
+                                println!(
+                                    "✅ Removed goal '{}' from project '{}'",
+                                    goal_id, proj.name
+                                );
                             }
                             Err(e) => {
                                 eprintln!("Failed to save project: {}", e);
@@ -1732,7 +2006,7 @@ fn handle_project_command(command: &ProjectCommands) {
                 }
             }
         }
-        
+
         ProjectCommands::AddContext { project, context } => {
             let project_id = match project {
                 Some(name) => {
@@ -1761,7 +2035,7 @@ fn handle_project_command(command: &ProjectCommands) {
                     }
                 }
             };
-            
+
             // Load or create project
             let mut proj = match project_manager.load_project(&project_id) {
                 Ok(Some(p)) => p,
@@ -1800,7 +2074,10 @@ fn handle_project_command(command: &ProjectCommands) {
             }
         }
 
-        ProjectCommands::RemoveContext { project, context_id } => {
+        ProjectCommands::RemoveContext {
+            project,
+            context_id,
+        } => {
             let project_id = match project {
                 Some(name) => {
                     // Find project by name
@@ -1828,13 +2105,16 @@ fn handle_project_command(command: &ProjectCommands) {
                     }
                 }
             };
-            
+
             match project_manager.load_project(&project_id) {
                 Ok(Some(mut proj)) => {
                     if proj.remove_context(context_id) {
                         match project_manager.save_project(&proj) {
                             Ok(_) => {
-                                println!("✅ Removed context '{}' from project '{}'", context_id, proj.name);
+                                println!(
+                                    "✅ Removed context '{}' from project '{}'",
+                                    context_id, proj.name
+                                );
                             }
                             Err(e) => {
                                 eprintln!("Failed to save project: {}", e);
@@ -1842,7 +2122,10 @@ fn handle_project_command(command: &ProjectCommands) {
                             }
                         }
                     } else {
-                        eprintln!("Context '{}' not found in project '{}'", context_id, proj.name);
+                        eprintln!(
+                            "Context '{}' not found in project '{}'",
+                            context_id, proj.name
+                        );
                         std::process::exit(1);
                     }
                 }
@@ -1856,7 +2139,7 @@ fn handle_project_command(command: &ProjectCommands) {
                 }
             }
         }
-        
+
         ProjectCommands::RemoveFile { project, file_id } => {
             let project_id = match project {
                 Some(name) => {
@@ -1885,7 +2168,7 @@ fn handle_project_command(command: &ProjectCommands) {
                     }
                 }
             };
-            
+
             match project_manager.load_project(&project_id) {
                 Ok(Some(mut proj)) => {
                     // Remove from project metadata
@@ -1894,10 +2177,13 @@ fn handle_project_command(command: &ProjectCommands) {
                         if let Err(e) = project_manager.delete_file(&project_id, file_id) {
                             eprintln!("Warning: Failed to delete file from disk: {}", e);
                         }
-                        
+
                         match project_manager.save_project(&proj) {
                             Ok(_) => {
-                                println!("✅ Removed file '{}' from project '{}'", file_id, proj.name);
+                                println!(
+                                    "✅ Removed file '{}' from project '{}'",
+                                    file_id, proj.name
+                                );
                             }
                             Err(e) => {
                                 eprintln!("Failed to save project: {}", e);
@@ -1919,7 +2205,7 @@ fn handle_project_command(command: &ProjectCommands) {
                 }
             }
         }
-        
+
         ProjectCommands::Show { project } => {
             let project_id = match project {
                 Some(name) => {
@@ -1948,7 +2234,7 @@ fn handle_project_command(command: &ProjectCommands) {
                     }
                 }
             };
-            
+
             match project_manager.load_project(&project_id) {
                 Ok(Some(proj)) => {
                     println!("Project Details:");
@@ -1956,17 +2242,22 @@ fn handle_project_command(command: &ProjectCommands) {
                     println!("  ID: {}", proj.id);
                     println!("  Created: {}", proj.created_at.format("%Y-%m-%d %H:%M:%S"));
                     println!("  Updated: {}", proj.updated_at.format("%Y-%m-%d %H:%M:%S"));
-                    
+
                     println!("\nGoals ({}):", proj.goals.len());
                     for goal in &proj.goals {
                         println!("  {}. {} (ID: {})", goal.order + 1, goal.text, goal.id);
                     }
-                    
+
                     println!("\nContexts ({}):", proj.contexts.len());
                     for context in &proj.contexts {
-                        println!("  {}. {} (ID: {})", context.order + 1, context.text, context.id);
+                        println!(
+                            "  {}. {} (ID: {})",
+                            context.order + 1,
+                            context.text,
+                            context.id
+                        );
                     }
-                    
+
                     println!("\nFiles ({}):", proj.files.len());
                     for file in &proj.files {
                         println!("  {} - {} ({} bytes)", file.filename, file.id, file.size);
@@ -1998,7 +2289,14 @@ fn handle_project_command(command: &ProjectCommands) {
             }
         }
 
-        ProjectCommands::Run { project, goals, format, warnings, clipboard, no_thinking } => {
+        ProjectCommands::Run {
+            project,
+            goals,
+            format,
+            warnings,
+            clipboard,
+            no_thinking,
+        } => {
             let project_id = match project {
                 Some(name) => {
                     // Find project by name
@@ -2022,7 +2320,7 @@ fn handle_project_command(command: &ProjectCommands) {
                     project_manager.get_active_project().unwrap_or(None)
                 }
             };
-            
+
             match prompt::structure_reasoning_with_project(
                 project_id.as_deref(),
                 goals,
@@ -2049,15 +2347,15 @@ fn handle_console_command(demo: bool, loading: Option<String>, duration: u64) {
     if demo {
         println!("🖥️  Console Features Demo");
         println!("Running the basic console example...\n");
-        
+
         if let Err(e) = console_utils::demo_console_features() {
             eprintln!("Console demo failed: {}", e);
             std::process::exit(1);
         }
-        
+
         println!("Demo completed!");
     }
-    
+
     if let Some(ref message) = loading {
         if let Err(e) = console_utils::loading_animation(message, duration) {
             eprintln!("Loading animation failed: {}", e);
@@ -2065,7 +2363,7 @@ fn handle_console_command(demo: bool, loading: Option<String>, duration: u64) {
         }
         println!("✅ Loading complete!");
     }
-    
+
     if !demo && loading.is_none() {
         println!("Console utilities available. Use --demo or --loading <message> to see examples.");
         println!("Examples:");

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,14 +1,13 @@
 // Prompt handling logic module
-use serde_json::json;
-use std::path::Path;
-use std::fs;
 use regex::Regex;
+use serde_json::json;
+use std::fs;
+use std::path::Path;
 
 use crate::api::{create_api_client_from_config, format_prompt};
-use crate::utils::{clipboard, output, piping};
-use crate::project::ProjectManager;
 use crate::models::Project;
-
+use crate::project::ProjectManager;
+use crate::utils::{clipboard, output, piping};
 
 /// Main function for structured reasoning with <think> blocks
 pub fn structure_reasoning(
@@ -19,19 +18,33 @@ pub fn structure_reasoning(
     context: Option<&str>,
     no_thinking: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Try to load settings
+    execute_reasoning_pass(
+        goals,
+        return_type,
+        warnings,
+        clipboard,
+        context,
+        no_thinking,
+    )?;
+
+    Ok(())
+}
+
+fn execute_reasoning_pass(
+    goals: &str,
+    return_type: &str,
+    warnings: &str,
+    clipboard: bool,
+    context: Option<&str>,
+    no_thinking: bool,
+) -> Result<String, Box<dyn std::error::Error>> {
     let settings = crate::settings::Settings::load().unwrap_or_default();
-    
-    // Format the prompt with goals, return type, warnings, and optional context
+
     let mut input_data = format_prompt(goals, return_type, warnings, context);
-    
-    // Read and append hints if available
     append_hints_if_available(&mut input_data)?;
-    
-    // Load current configuration and create API client
+
     let api_client = create_api_client_from_config()?;
-    
-    // Use model from config, settings, or fallback to default
+
     let config = crate::config::Config::load()?;
     let provider_config = config.get_active_provider().ok_or_else(|| {
         std::io::Error::new(
@@ -39,30 +52,30 @@ pub fn structure_reasoning(
             "No active provider configured. Run 'ola configure' first.",
         )
     })?;
-    
+
     let model = provider_config
         .model
         .as_deref()
         .unwrap_or(&settings.default_model);
-    output::println_colored(&format!("🧠 Using model: {}", model), output::Color::BrightBlue);
-    
-    // Stream the response
+    output::println_colored(
+        &format!("🧠 Using model: {}", model),
+        output::Color::BrightBlue,
+    );
+
     let response = stream_response(&api_client, &input_data, model, no_thinking)?;
-    
-    // Handle clipboard copy if requested
+
     if clipboard {
         match clipboard::copy_to_clipboard(&response) {
             Ok(_) => output::print_success("Response copied to clipboard"),
-            Err(e) => output::print_error(&format!("Failed to copy to clipboard: {}", e))
+            Err(e) => output::print_error(&format!("Failed to copy to clipboard: {}", e)),
         }
     }
-    
-    // Log session if enabled in settings
+
     if settings.behavior.enable_logging {
         log_session(goals, return_type, warnings, model, &response)?;
     }
-    
-    Ok(())
+
+    Ok(response)
 }
 
 /// Stream raw prompt without structured reasoning
@@ -74,20 +87,20 @@ pub fn stream_non_think(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Try to load settings
     let settings = crate::settings::Settings::load().unwrap_or_default();
-    
+
     // Format the prompt with optional context
     let mut input_data = if let Some(ctx) = context {
         format!("{}\nContext: {}", prompt, ctx)
     } else {
         prompt.to_string()
     };
-    
+
     // Read and append hints if available
     append_hints_if_available(&mut input_data)?;
-    
+
     // Create API client
     let api_client = create_api_client_from_config()?;
-    
+
     // Get model information
     let config = crate::config::Config::load()?;
     let provider_config = config.get_active_provider().ok_or_else(|| {
@@ -96,24 +109,27 @@ pub fn stream_non_think(
             "No active provider configured. Run 'ola configure' first.",
         )
     })?;
-    
+
     let model = provider_config
         .model
         .as_deref()
         .unwrap_or(&settings.default_model);
-    output::println_colored(&format!("🧠 Using model: {}", model), output::Color::BrightBlue);
-    
+    output::println_colored(
+        &format!("🧠 Using model: {}", model),
+        output::Color::BrightBlue,
+    );
+
     // Stream the response
     let response = stream_response(&api_client, &input_data, model, filter_thinking)?;
-    
+
     // Handle clipboard copy if requested
     if clipboard {
         match clipboard::copy_to_clipboard(&response) {
             Ok(_) => output::print_success("Response copied to clipboard"),
-            Err(e) => output::print_error(&format!("Failed to copy to clipboard: {}", e))
+            Err(e) => output::print_error(&format!("Failed to copy to clipboard: {}", e)),
         }
     }
-    
+
     // Log session if enabled in settings
     if settings.behavior.enable_logging {
         let log_entry = json!({
@@ -122,12 +138,12 @@ pub fn stream_non_think(
             "model": model,
             "output_length": response.len(),
         });
-        
+
         if let Err(e) = piping::append_to_log(&settings.behavior.log_file, &log_entry.to_string()) {
             eprintln!("Failed to log session: {}", e);
         }
     }
-    
+
     Ok(())
 }
 
@@ -136,23 +152,23 @@ fn stream_response(
     api_client: &crate::api::ApiClient,
     prompt: &str,
     model: &str,
-    filter_thinking: bool
+    filter_thinking: bool,
 ) -> Result<String, Box<dyn std::error::Error>> {
     // Show loading animation while waiting for response
     output::print_wave_animation(0, "Generating response");
     std::thread::sleep(std::time::Duration::from_millis(500));
-    
+
     // Add some visual feedback for the request
     output::clear_line();
     output::println_colored("⚡ Sending prompt to AI...", output::Color::BrightYellow);
-    
+
     // Get the raw response
     let response = api_client.stream_prompt(prompt, model)?;
-    
+
     // Clear and show completion
     output::println_colored("✨ Response received!", output::Color::BrightGreen);
     println!(); // Add some space before output
-    
+
     // If we need to filter thinking blocks, process the response
     if filter_thinking {
         output::println_colored("🔄 Filtering thinking blocks...", output::Color::BrightCyan);
@@ -169,7 +185,7 @@ fn stream_response(
 fn append_hints_if_available(input_data: &mut String) -> Result<(), Box<dyn std::error::Error>> {
     // Try to read hints from a local .olaHints file; if not found, fallback to global hints
     let mut hints = String::new();
-    
+
     // Check local file .olaHints in the current directory
     if Path::new("./.olaHints").exists() {
         hints = fs::read_to_string("./.olaHints")?;
@@ -187,7 +203,7 @@ fn append_hints_if_available(input_data: &mut String) -> Result<(), Box<dyn std:
     if !hints.is_empty() {
         input_data.push_str(&format!("\nHINTS: {}", hints));
     }
-    
+
     Ok(())
 }
 
@@ -197,15 +213,15 @@ fn log_session(
     return_type: &str,
     warnings: &str,
     model: &str,
-    response: &str
+    response: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let settings = crate::settings::Settings::load().unwrap_or_default();
-    
+
     // Get recursion wave number if present
     let wave_number = std::env::var("OLA_RECURSION_WAVE")
         .ok()
         .and_then(|s| s.parse::<u8>().ok());
-    
+
     // Build log entry with optional recursion information
     let mut log_entry = json!({
         "timestamp": chrono::Utc::now().to_rfc3339(),
@@ -215,12 +231,12 @@ fn log_session(
         "model": model,
         "output_length": response.len(),
     });
-    
+
     // Add recursion wave info if available
     if let Some(wave) = wave_number {
         log_entry["recursion_wave"] = json!(wave);
     }
-    
+
     piping::append_to_log(&settings.behavior.log_file, &log_entry.to_string())?;
     Ok(())
 }
@@ -237,33 +253,118 @@ pub fn interactive_iterations(
 ) -> Result<(), Box<dyn std::error::Error>> {
     for iteration in 1..=max_iterations {
         println!();
-        output::print_banner(&format!("🔄 Iteration {}/{} 🔄", iteration, max_iterations), output::Color::BrightCyan);
+        output::print_banner(
+            &format!("🔄 Iteration {}/{} 🔄", iteration, max_iterations),
+            output::Color::BrightCyan,
+        );
         println!();
-        
+
         // Execute the structured reasoning for this iteration
-        structure_reasoning(goals, return_type, warnings, clipboard, context, no_thinking)?;
-        
+        structure_reasoning(
+            goals,
+            return_type,
+            warnings,
+            clipboard,
+            context,
+            no_thinking,
+        )?;
+
         // For now, we'll just run the same prompt multiple times
         // In a more advanced version, we could collect feedback between iterations
         if iteration < max_iterations {
             println!();
-            output::print_success(&format!("Completed iteration {} of {}", iteration, max_iterations));
+            output::print_success(&format!(
+                "Completed iteration {} of {}",
+                iteration, max_iterations
+            ));
             output::print_wave_animation(iteration as usize, "Preparing next iteration...");
             std::thread::sleep(std::time::Duration::from_millis(800));
             output::clear_line();
         }
     }
-    
+
     println!();
     output::print_rainbow(&format!("🎉 Completed {} iterations! 🎉", max_iterations));
     Ok(())
 }
 
+/// Ralph loop: iterative self-refinement with short-term memory across passes.
+pub fn ralph_loop(
+    goals: &str,
+    return_type: &str,
+    warnings: &str,
+    clipboard: bool,
+    context: Option<&str>,
+    no_thinking: bool,
+    passes: u8,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut memory: Option<String> = None;
+
+    for pass in 1..=passes {
+        println!();
+        output::print_banner(
+            &format!("🧠 Ralph Core Pass {}/{}", pass, passes),
+            output::Color::BrightMagenta,
+        );
+        println!();
+
+        let prior = memory.as_deref().unwrap_or("No prior answer yet.");
+        let loop_instruction = format!(
+            "Ralph loop pass {}/{}:
+- critique the prior answer
+- identify weak assumptions
+- improve structure and precision
+- output a stronger final answer in the requested format.",
+            pass, passes
+        );
+
+        let pass_warnings = if warnings.is_empty() {
+            loop_instruction
+        } else {
+            format!("{}\n{}", warnings, loop_instruction)
+        };
+
+        let memory_context = match context {
+            Some(ctx) => format!(
+                "{}\n\n# Ralph Memory\nPrevious pass output:\n{}",
+                ctx, prior
+            ),
+            None => format!("# Ralph Memory\nPrevious pass output:\n{}", prior),
+        };
+
+        let response = execute_reasoning_pass(
+            goals,
+            return_type,
+            &pass_warnings,
+            clipboard,
+            Some(&memory_context),
+            no_thinking,
+        )?;
+
+        memory = Some(response);
+
+        if pass < passes {
+            println!();
+            output::print_success(&format!("Completed Ralph pass {} of {}", pass, passes));
+            output::print_wave_animation(pass as usize, "Ralph is planning the next move...");
+            std::thread::sleep(std::time::Duration::from_millis(700));
+            output::clear_line();
+        }
+    }
+
+    println!();
+    output::print_rainbow(&format!("🎯 Ralph loop complete ({} passes)! 🎯", passes));
+    Ok(())
+}
+
 /// Enhanced prompt building that includes project files, goals, and contexts
-pub fn build_project_prompt(project: &Project, user_prompt: Option<&str>) -> Result<String, Box<dyn std::error::Error>> {
+pub fn build_project_prompt(
+    project: &Project,
+    user_prompt: Option<&str>,
+) -> Result<String, Box<dyn std::error::Error>> {
     let project_manager = ProjectManager::new()?;
     let mut prompt_parts = Vec::new();
-    
+
     // Add goals section if any goals exist
     if !project.goals.is_empty() {
         prompt_parts.push("## Project Goals".to_string());
@@ -272,7 +373,7 @@ pub fn build_project_prompt(project: &Project, user_prompt: Option<&str>) -> Res
         }
         prompt_parts.push("".to_string()); // Empty line
     }
-    
+
     // Add contexts section if any contexts exist
     if !project.contexts.is_empty() {
         prompt_parts.push("## Context Information".to_string());
@@ -281,25 +382,28 @@ pub fn build_project_prompt(project: &Project, user_prompt: Option<&str>) -> Res
         }
         prompt_parts.push("".to_string()); // Empty line
     }
-    
+
     // Add files section if any files exist
     if !project.files.is_empty() {
         prompt_parts.push("## Project Files".to_string());
-        
+
         for file in &project.files {
             prompt_parts.push(format!("### File: {}", file.filename));
-            
+
             // Try to read file content as text
             match project_manager.read_file_as_text(&project.id, &file.id) {
                 Ok(Some(content)) => {
                     // Limit file content to prevent prompt from becoming too large
                     let content = if content.len() > 10000 {
-                        format!("{}...\n[Content truncated - file is {} bytes]", 
-                               &content[..10000], file.size)
+                        format!(
+                            "{}...\n[Content truncated - file is {} bytes]",
+                            &content[..10000],
+                            file.size
+                        )
                     } else {
                         content
                     };
-                    
+
                     prompt_parts.push("```".to_string());
                     prompt_parts.push(content);
                     prompt_parts.push("```".to_string());
@@ -314,7 +418,7 @@ pub fn build_project_prompt(project: &Project, user_prompt: Option<&str>) -> Res
             prompt_parts.push("".to_string()); // Empty line between files
         }
     }
-    
+
     // Add user prompt if provided
     if let Some(user_input) = user_prompt {
         if !prompt_parts.is_empty() {
@@ -322,7 +426,7 @@ pub fn build_project_prompt(project: &Project, user_prompt: Option<&str>) -> Res
         }
         prompt_parts.push(user_input.to_string());
     }
-    
+
     Ok(prompt_parts.join("\n"))
 }
 
@@ -337,37 +441,40 @@ pub fn structure_reasoning_with_project(
     no_thinking: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let project_manager = ProjectManager::new()?;
-    
+
     // Load project or use default
     let project = if let Some(id) = project_id {
         project_manager.load_project(id)?.ok_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::NotFound, format!("Project not found: {}", id))
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("Project not found: {}", id),
+            )
         })?
     } else {
         project_manager.get_default_project()?
     };
-    
+
     // Build enhanced prompt with project data
     let mut enhanced_prompt = build_project_prompt(&project, Some(goals))?;
-    
+
     // Add additional context if provided
     if let Some(ctx) = context {
         enhanced_prompt = format!("{}\n\nAdditional Context: {}", enhanced_prompt, ctx);
     }
-    
+
     // Try to load settings
     let settings = crate::settings::Settings::load().unwrap_or_default();
-    
+
     // Format the prompt with enhanced content
     let input_data = format_prompt(&enhanced_prompt, return_type, warnings, None);
-    
+
     // Read and append hints if available
     let mut final_input = input_data;
     append_hints_if_available(&mut final_input)?;
-    
+
     // Load current configuration and create API client
     let api_client = create_api_client_from_config()?;
-    
+
     // Use model from config, settings, or fallback to default
     let config = crate::config::Config::load()?;
     let provider_config = config.get_active_provider().ok_or_else(|| {
@@ -376,29 +483,32 @@ pub fn structure_reasoning_with_project(
             "No active provider configured. Run 'ola configure' first.",
         )
     })?;
-    
+
     let model = provider_config
         .model
         .as_deref()
         .unwrap_or(&settings.default_model);
-    output::println_colored(&format!("🧠 Using model: {} with project: {}", model, project.name), output::Color::BrightBlue);
-    
+    output::println_colored(
+        &format!("🧠 Using model: {} with project: {}", model, project.name),
+        output::Color::BrightBlue,
+    );
+
     // Stream the response
     let response = stream_response(&api_client, &final_input, model, no_thinking)?;
-    
+
     // Handle clipboard copy if requested
     if clipboard {
         match clipboard::copy_to_clipboard(&response) {
             Ok(_) => output::print_success("Response copied to clipboard"),
-            Err(e) => output::print_error(&format!("Failed to copy to clipboard: {}", e))
+            Err(e) => output::print_error(&format!("Failed to copy to clipboard: {}", e)),
         }
     }
-    
+
     // Log session if enabled in settings
     if settings.behavior.enable_logging {
         log_session(&enhanced_prompt, return_type, warnings, model, &response)?;
     }
-    
+
     Ok(())
 }
 
@@ -420,7 +530,7 @@ pub fn structure_reasoning_test(
 ) -> Result<PromptResult, Box<dyn std::error::Error>> {
     // This is a testable version that returns the response instead of printing it
     let settings = crate::settings::Settings::load().unwrap_or_default();
-    
+
     // Load configuration
     let config = crate::config::Config::load()?;
     let provider_config = config.get_active_provider().ok_or_else(|| {
@@ -435,11 +545,14 @@ pub fn structure_reasoning_test(
         .model
         .as_deref()
         .unwrap_or(&settings.default_model);
-    
+
     // Here's where we would mock the API call in tests
     // For testing, we'll just return the input as the response
     Ok(PromptResult {
-        content: format!("This is a mocked response from the {} API.", provider_config.provider),
+        content: format!(
+            "This is a mocked response from the {} API.",
+            provider_config.provider
+        ),
         model: model.to_string(),
     })
 }
@@ -453,7 +566,7 @@ pub fn stream_non_think_test(
 ) -> Result<PromptResult, Box<dyn std::error::Error>> {
     // This is a testable version that returns the response instead of printing it
     let settings = crate::settings::Settings::load().unwrap_or_default();
-    
+
     // Load configuration
     let config = crate::config::Config::load()?;
     let provider_config = config.get_active_provider().ok_or_else(|| {
@@ -468,12 +581,14 @@ pub fn stream_non_think_test(
         .model
         .as_deref()
         .unwrap_or(&settings.default_model);
-    
+
     // Here's where we would mock the API call in tests
     // For testing, we'll just return the input as the response
     Ok(PromptResult {
-        content: format!("This is a mocked response from the {} API.", provider_config.provider),
+        content: format!(
+            "This is a mocked response from the {} API.",
+            provider_config.provider
+        ),
         model: model.to_string(),
     })
 }
-

--- a/tests/cli_prompt_test.rs
+++ b/tests/cli_prompt_test.rs
@@ -7,8 +7,12 @@ use tempfile::tempdir;
 fn test_prompt_help() {
     // Test help text for the prompt command
     let mut cmd = Command::cargo_bin("ola").unwrap();
-    let output = cmd.arg("prompt").arg("--help").output().expect("Failed to execute command");
-    
+    let output = cmd
+        .arg("prompt")
+        .arg("--help")
+        .output()
+        .expect("Failed to execute command");
+
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("--goals"));
     assert!(stdout.contains("--format"));
@@ -25,7 +29,7 @@ fn test_prompt_help() {
 fn test_prompt_quiet_flag() {
     // When using --quiet flag, there should be no output to stderr
     let mut cmd = Command::cargo_bin("ola").unwrap();
-    
+
     // Mock the input that would normally be requested interactively
     let output = cmd
         .arg("prompt")
@@ -35,7 +39,7 @@ fn test_prompt_quiet_flag() {
         .write_stdin("test\ntext\n\n") // Mock the interactive input
         .output()
         .expect("Failed to execute command");
-    
+
     // With --quiet, no welcome message should be printed
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.is_empty());
@@ -47,7 +51,7 @@ fn test_prompt_clipboard_flag() {
     // Testing --clipboard flag requires platform-specific tests
     // This is a basic test that just ensures the flag doesn't cause errors
     let mut cmd = Command::cargo_bin("ola").unwrap();
-    
+
     cmd.arg("prompt")
         .arg("--goals")
         .arg("test goals")
@@ -55,7 +59,7 @@ fn test_prompt_clipboard_flag() {
         .write_stdin("test\ntext\n\n")
         .assert()
         .success();
-    
+
     // We can't easily verify clipboard contents in a cross-platform test
     // So we just ensure the command executes successfully
 }
@@ -65,7 +69,7 @@ fn test_prompt_clipboard_flag() {
 fn test_prompt_pipe_flag() {
     // Test the --pipe flag by providing input via stdin
     let mut cmd = Command::cargo_bin("ola").unwrap();
-    
+
     cmd.arg("prompt")
         .arg("--pipe")
         .arg("--goals")
@@ -73,7 +77,7 @@ fn test_prompt_pipe_flag() {
         .write_stdin("This is piped content\n")
         .assert()
         .success();
-        
+
     // The piped content should be used as context
     // We'd need to mock the API responses to fully verify this
 }
@@ -83,7 +87,7 @@ fn test_prompt_pipe_flag() {
 fn test_prompt_recursion_flag() {
     // Test the basic recursion flag without actually running multiple recursions
     let mut cmd = Command::cargo_bin("ola").unwrap();
-    
+
     // Set recursion to 1 (which should be the same as no recursion)
     cmd.arg("prompt")
         .arg("--goals")
@@ -93,7 +97,7 @@ fn test_prompt_recursion_flag() {
         .write_stdin("test\ntext\n\n")
         .assert()
         .success();
-        
+
     // The real recursion tests would need to mock the environment variables
     // and verify that multiple processes are launched
 }
@@ -103,7 +107,7 @@ fn test_prompt_recursion_flag() {
 fn test_prompt_format_flag() {
     // Test specifying a custom format
     let mut cmd = Command::cargo_bin("ola").unwrap();
-    
+
     cmd.arg("prompt")
         .arg("--goals")
         .arg("test format")
@@ -112,7 +116,7 @@ fn test_prompt_format_flag() {
         .write_stdin("test\n")
         .assert()
         .success();
-    
+
     // We'd need to mock the API call to verify the format is passed correctly
 }
 
@@ -121,7 +125,7 @@ fn test_prompt_format_flag() {
 fn test_prompt_warnings_flag() {
     // Test specifying warnings
     let mut cmd = Command::cargo_bin("ola").unwrap();
-    
+
     cmd.arg("prompt")
         .arg("--goals")
         .arg("test warnings")
@@ -130,7 +134,7 @@ fn test_prompt_warnings_flag() {
         .write_stdin("test\n")
         .assert()
         .success();
-    
+
     // We'd need to mock the API call to verify the warnings are passed correctly
 }
 
@@ -139,7 +143,7 @@ fn test_prompt_warnings_flag() {
 fn test_prompt_no_thinking_flag() {
     // Test the --no-thinking flag
     let mut cmd = Command::cargo_bin("ola").unwrap();
-    
+
     cmd.arg("prompt")
         .arg("--goals")
         .arg("test no thinking")
@@ -147,6 +151,6 @@ fn test_prompt_no_thinking_flag() {
         .write_stdin("test\ntext\n\n")
         .assert()
         .success();
-    
+
     // We'd need to mock the API responses to verify this works correctly
 }


### PR DESCRIPTION
### Motivation

- Ralph loops are the primary reasoning workflow and should be the default engine rather than an optional CLI flag.
- Provide short-term memory and structured self-refinement across passes to make iterative refinement agentic and useful out-of-the-box.
- Simplify CLI surface by removing the separate `--ralph-loop` flag and reuse `--iterations` as pass count control.

### Description

- Removed the `--ralph-loop` CLI option and made the Ralph loop the default execution path for `ola prompt`, using `--iterations` (defaulting to 3) as the pass count in `run_prompt` (`src/main.rs`).
- Introduced `execute_reasoning_pass(...)` that returns the response text and refactored `structure_reasoning(...)` to call it, enabling pass-to-pass memory (`src/prompt.rs`).
- Upgraded `prompt::ralph_loop(...)` to maintain short-term memory by injecting the previous pass output into the subsequent pass context and to emit stronger per-pass refinement instructions (`src/prompt.rs`).
- Kept recursion behavior intact and forward `--iterations` to recursion child processes; removed forwarding of the old `--ralph-loop` flag (`src/main.rs`).
- Updated documentation to describe Ralph as the core engine and show usage examples with `--iterations` (`README.md`).
- Updated the prompt help test to remove the expectation for `--ralph-loop` (`tests/cli_prompt_test.rs`).

### Testing

- Ran `cargo test test_prompt_help` and the test passed.
- Ran `cargo test test_cli_help` and the test passed.
- Ran formatting via `rustfmt` and ensured the code compiles while automated tests succeeded for the changed help tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699989ff7d44832a84ac8fbee816ae1b)